### PR TITLE
Fix typo in out_dir of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERBOSE		:= 0
 
 OBJ_DIR		:= .obj
 OBJ_EXT		:= o
-OUT_DIR		:= .bin
+OUT_DIR		:= ./bin
 OUT_NAME	:= bladebit
 Q			:= @
 


### PR DESCRIPTION
Hello, frist of all nice work!
Noticed a typo in Make file, needs a forward slash