### PR TITLE
Fallocate plot files in background upon creation

### DIFF
--- a/src/platform/unix/FileStream_Unix.cpp
+++ b/src/platform/unix/FileStream_Unix.cpp
@@ -18,7 +18,7 @@ void* fallocate_in_background(void* rawfd) {
 
     pthread_detach(pthread_self());
 
-    printf("Fallocating files...\n");
+    Log::Line("Fallocating files...");
     struct timeval begin, end;
     gettimeofday(&begin, 0);
 
@@ -28,13 +28,13 @@ void* fallocate_in_background(void* rawfd) {
     gettimeofday(&end, 0);
 
     if (res < 0) {
-        printf("Fallocate failed %d %d\n", res, errno);
+        Log::Line("Fallocate failed, errno %d", errno);
     } else {
         long seconds = end.tv_sec - begin.tv_sec;
         long microseconds = end.tv_usec - begin.tv_usec;
         double elapsed = seconds + microseconds*1e-6;
 
-        printf("Fallocate successed in %.2f seconds.\n", elapsed);
+        Log::Line("Fallocate succeeded in %.2f seconds.", elapsed);
     }
 
     pthread_exit(nullptr);


### PR DESCRIPTION
Once hdd is being filled up to 80%+ allocating 101.5GiB of data can take up to 30-60 extra seconds. That is usually used during plot writing stage (3, 4 and waiting for prev plot in stage 1).

In this patch i'm using fallocate system call and run it in background thread after plot file creation. Linux optimizes this -- fallocate process takes lowest IO prio in filesystem -- so, it does not affect previous plot writing speeds at all.

This can have different impact on various filesystems, I'm using ext4 with data=writeback.